### PR TITLE
ci: Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,5 +1,9 @@
 name: "Semantic PRs"
 
+permissions:
+  contents: read
+  pull-requests: read
+
 on:
   pull_request_target:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-design/security/code-scanning/2](https://github.com/openfoodfacts/openfoodfacts-design/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow validates PR titles, it only needs read access to the repository contents and pull request metadata. We will set `contents: read` and `pull-requests: read` at the workflow level, which will apply to all jobs in the workflow. This ensures that the `GITHUB_TOKEN` has the minimal permissions required to perform the task.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
