### PR TITLE
ci: Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-design/security/code-scanning/3](https://github.com/openfoodfacts/openfoodfacts-design/security/code-scanning/3)

To fix the issue, add a `permissions` block to the workflow. This block should specify the minimal permissions required for the `release-please-action` to function correctly. Based on the typical requirements of this action, the permissions should include `contents: read` and `pull-requests: write`. These permissions allow the workflow to read repository contents and create or update pull requests, which are essential for release automation.

The `permissions` block should be added at the job level (`release-please`) to limit its scope to this specific job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
