### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/top-issues.yml
+++ b/.github/workflows/top-issues.yml
@@ -13,6 +13,9 @@ jobs:
   ShowAndLabelTopIssues:
     name: Display and label top issues.
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
     - name: Run top issues action
       uses: rickstaa/top-issues-action@v1


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-design/security/code-scanning/4](https://github.com/openfoodfacts/openfoodfacts-design/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow uses the `GITHUB_TOKEN` to interact with GitHub resources, we will assign the least privileges required for the action to function correctly. Based on the action's purpose (displaying and labeling top issues), it likely requires `contents: read` to read repository data and `issues: write` to label issues. These permissions will be added at the job level to limit their scope to the specific job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
